### PR TITLE
bug: make sampler work when NaN values are predicted by the models

### DIFF
--- a/src/autora/experimentalist/model_disagreement/__init__.py
+++ b/src/autora/experimentalist/model_disagreement/__init__.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 from typing import Iterable, List, Optional, Union
 
 import numpy as np
@@ -90,8 +91,10 @@ def score_sample(
         else:
             disagreement = np.mean((y_a - y_b) ** 2, axis=1)
 
+        if np.isinf(disagreement).any() or np.isnan(disagreement).any():
+            warnings.warn('Found nan or inf values in model predictions, '
+                          'setting disagreement there to 0')
         disagreement[np.isinf(disagreement)] = 0
-
         disagreement = np.nan_to_num(disagreement)
 
         model_disagreement.append(disagreement)

--- a/tests/test_model_disagreement_sampler.py
+++ b/tests/test_model_disagreement_sampler.py
@@ -1,32 +1,43 @@
-from src.autora.experimentalist.model_disagreement import model_disagreement_sample, model_disagreement_score_sample
-from autora.theorist.bms import BMSRegressor; BMSRegressor()
-from autora.theorist.darts import DARTSRegressor; DARTSRegressor()
 import numpy as np
 import pandas as pd
 
+from autora.experimentalist.model_disagreement import (
+    model_disagreement_sample,
+    model_disagreement_score_sample,
+)
+from autora.theorist.bms import BMSRegressor
+from autora.theorist.darts import DARTSRegressor
+
+BMSRegressor()
+
+
+DARTSRegressor()
+
+
 def test_output_dimensions():
-    #Meta-Setup
+    # Meta-Setup
     X = np.linspace(start=-3, stop=6, num=10).reshape(-1, 1)
     y = (X**2).reshape(-1, 1)
     n = 5
-    
-    #Theorists
+
+    # Theorists
     bms_theorist = BMSRegressor(epochs=10)
     darts_theorist = DARTSRegressor(max_epochs=10)
-    
-    bms_theorist.fit(X,y)
-    darts_theorist.fit(X,y)
 
-    #Sampler
+    bms_theorist.fit(X, y)
+    darts_theorist.fit(X, y)
+
+    # Sampler
     X_new = model_disagreement_sample(X, [bms_theorist, darts_theorist], n)
 
     # Check that the sampler returns n experiment conditions
     assert X_new.shape == (n, X.shape[1])
 
+
 def test_pandas():
     # Meta-Setup
     X = np.linspace(start=-3, stop=6, num=10).reshape(-1, 1)
-    y = (X ** 2).reshape(-1, 1)
+    y = (X**2).reshape(-1, 1)
     n = 5
 
     X = pd.DataFrame(X)
@@ -45,10 +56,11 @@ def test_pandas():
     assert isinstance(X_new, pd.DataFrame)
     assert X_new.shape == (n, X.shape[1])
 
+
 def test_scoring():
     # Meta-Setup
     X = np.linspace(start=-3, stop=6, num=10).reshape(-1, 1)
-    y = (X ** 2).reshape(-1, 1)
+    y = (X**2).reshape(-1, 1)
     n = 5
 
     X = pd.DataFrame(X)


### PR DESCRIPTION
Sampler was breaking with an Error, if one of the models predicts NaN or Inf for a single condition.

Fix:
The disagrement (distance) between two models get's set to 0 if at least one of them predict NaN or Inf at that condition. 

Rationale:
- Throwing an Error is no good, since it breaks with a lot of models 
- Dropping the condition is no good, since some models would "clog" the sampler (For example, if a model is sqrt(x), this means no negative conditions get sampled anymore.
- Setting the distance to a high number would lead to overly sampling potentially uninformative conditions (especially if the ground truth actually is undefined at these condition)
-> Setting the distance to zero doesn't encourage sampling this condition, but also doesn't make it impossible.